### PR TITLE
Handle fractional timestamp parsing

### DIFF
--- a/duckdb.mbt
+++ b/duckdb.mbt
@@ -462,6 +462,27 @@ fn parse_timestamp(s : String) -> Result[Int, String] {
 }
 
 ///|
+/// Parse fractional seconds (up to 6 digits) into microseconds.
+fn parse_fraction_to_micros(s : String) -> Int {
+  let mut micros = 0
+  let mut factor = 100000
+  let mut i = 0
+  while i < s.length() {
+    let c = s[i]
+    if c < '0' || c > '9' {
+      break
+    }
+    let digit = c.to_int() - '0'.to_int()
+    if factor >= 1 {
+      micros = micros + digit * factor
+      factor = factor / 10
+    }
+    i = i + 1
+  }
+  micros
+}
+
+///|
 /// Parse time string (HH:MM:SS[.sss...]) to microseconds since midnight.
 fn parse_time_to_micros(s : String) -> Result[Int, String] {
   // Manual parsing since split() returns Iter
@@ -493,15 +514,22 @@ fn parse_time_to_micros(s : String) -> Result[Int, String] {
 
     // Parse seconds (may have fractional part)
     let dot_idx = find_dot(sec_part)
-    let second = match dot_idx {
-      Some(idx) =>
-        parse_int(sec_part.view(start_offset=0, end_offset=idx).to_string())
-      None => parse_int(sec_part)
+    let (second, frac_micros) = match dot_idx {
+      Some(idx) => {
+        let second = parse_int(
+          sec_part.view(start_offset=0, end_offset=idx).to_string(),
+        )
+        let frac = sec_part
+          .view(start_offset=idx + 1, end_offset=sec_part.length())
+          .to_string()
+        (second, parse_fraction_to_micros(frac))
+      }
+      None => (parse_int(sec_part), 0)
     }
     let hour = parse_int(hour_str)
     let minute = parse_int(minute_str)
-    let micros = (hour * 3600 + minute * 60 + second) * 1000000
-    Ok(micros)
+    let base = (hour * 3600 + minute * 60 + second) * 1000000
+    Ok(base + frac_micros)
   }
 }
 

--- a/duckdb_test.mbt
+++ b/duckdb_test.mbt
@@ -1130,6 +1130,29 @@ test "typed result date and timestamp" {
 }
 
 ///|
+test "typed result timestamp fractional seconds" {
+  let result = run_native_query(
+    "SELECT TIMESTAMP '2024-06-03 12:34:56.789123' AS ts",
+  )
+  match result {
+    Ok(query_result) => {
+      let typed = query_result.to_typed()
+      match typed.get_timestamp(0, 0) {
+        Some(micros) => {
+          let base = timestamp_from_ymd_hms(2024, 6, 3, 12, 34, 56)
+          let expected = base + 789123
+          if micros != expected {
+            fail("expected timestamp \{expected}, got \{micros}")
+          }
+        }
+        None => fail("expected Some(timestamp), got None")
+      }
+    }
+    Err(message) => fail("query failed: \{message}")
+  }
+}
+
+///|
 test "typed result columnar access" {
   let result = run_native_query(
     "SELECT * FROM (VALUES (1, 'a'), (2, 'b'), (3, NULL)) AS t(id, name)",


### PR DESCRIPTION
## Summary
- parse fractional seconds into microseconds for typed timestamp conversion
- add test coverage for fractional timestamp values

## Testing
- moon test

Refs #27
