### PR TITLE
feat: Add Property-Based Testing with Aletheia

### DIFF
--- a/duckdb.mbt
+++ b/duckdb.mbt
@@ -383,7 +383,7 @@ fn is_special_float_string(s : String) -> Bool {
 
 ///|
 /// Check if string represents an integer.
-fn is_integer(s : String) -> Bool {
+pub fn is_integer(s : String) -> Bool {
   if s.length() == 0 {
     false
   } else {
@@ -437,7 +437,7 @@ fn is_double(s : String) -> Bool {
 
 ///|
 /// Parse string to Int.
-fn parse_int(s : String) -> Int {
+pub fn parse_int(s : String) -> Int {
   let mut result = 0
   let mut i = 0
   let mut negative = false

--- a/duckdb_pbt_test.mbt
+++ b/duckdb_pbt_test.mbt
@@ -1,0 +1,129 @@
+///|
+/// Property-Based Tests for DuckDB MoonBit bindings
+/// Tests round-trip properties for date/timestamp conversion and integer parsing
+
+///|
+/// Check if year is a leap year (divisible by 4, not by 100, unless also by 400)
+fn _is_leap_year_internal(year : Int) -> Bool {
+  (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+}
+
+///|
+/// Property: date_from_ymd/date_to_ymd round-trip
+/// Converting a date to days and back should yield the original date
+test "prop_date_roundtrip" {
+  let gen = @pbt.Gen::choose_int(1970, 2100).bind(fn(year) {
+    @pbt.Gen::choose_int(1, 12).bind(fn(month) {
+      let max_day = match month {
+        2 => if _is_leap_year_internal(year) { 29 } else { 28 }
+        4 | 6 | 9 | 11 => 30
+        _ => 31
+      }
+      @pbt.Gen::choose_int(1, max_day).map(fn(day) { (year, month, day) })
+    })
+  })
+
+  let config = @pbt.CheckConfig::new(1000, 100, 12345, 50)
+  @pbt.assert_check(
+    "date_from_ymd/date_to_ymd round-trip",
+    gen,
+    fn(input) {
+      let (year, month, day) = input
+      let days = date_from_ymd(year, month, day)
+      let (y2, m2, d2) = date_to_ymd(days)
+      if y2 == year && m2 == month && d2 == day {
+        Ok(())
+      } else {
+        Err("(\{year}, \{month}, \{day}) -> \{days} -> (\{y2}, \{m2}, \{d2})")
+      }
+    },
+    config~,
+  )
+}
+
+///|
+/// Property: timestamp_from_ymd_hms/timestamp_to_ymd_hms round-trip
+/// Converting a timestamp to microseconds and back should yield the original timestamp
+test "prop_timestamp_roundtrip" {
+  let gen = @pbt.Gen::choose_int(1970, 2100).bind(fn(year) {
+    @pbt.Gen::choose_int(1, 12).bind(fn(month) {
+      let max_day = match month {
+        2 => if _is_leap_year_internal(year) { 29 } else { 28 }
+        4 | 6 | 9 | 11 => 30
+        _ => 31
+      }
+      @pbt.Gen::choose_int(1, max_day).map(fn(day) { (year, month, day) })
+    })
+  }).bind(fn(date) {
+    let (year, month, day) = date
+    @pbt.Gen::choose_int(0, 23).bind(fn(hour) {
+      @pbt.Gen::choose_int(0, 59).bind(fn(minute) {
+        @pbt.Gen::choose_int(0, 59).map(fn(second) {
+          (year, month, day, hour, minute, second)
+        })
+      })
+    })
+  })
+
+  let config = @pbt.CheckConfig::new(1000, 100, 54321, 50)
+  @pbt.assert_check(
+    "timestamp round-trip",
+    gen,
+    fn(input) {
+      let (year, month, day, hour, minute, second) = input
+      let micros = timestamp_from_ymd_hms(year, month, day, hour, minute, second)
+      let (y2, m2, d2, h2, min2, s2) = timestamp_to_ymd_hms(micros)
+      if y2 == year && m2 == month && d2 == day &&
+         h2 == hour && min2 == minute && s2 == second {
+        Ok(())
+      } else {
+        Err("(\{year}-\{month}-\{day} \{hour}:\{minute}:\{second}) != (\{y2}-\{m2}-\{d2} \{h2}:\{min2}:\{s2})")
+      }
+    },
+    config~,
+  )
+}
+
+///|
+/// Property: Int -> String -> Int round-trip
+/// Converting an integer to string and parsing should yield the original integer
+test "prop_parse_int_roundtrip" {
+  let config = @pbt.CheckConfig::new(500, 100, 11111, 20)
+  let gen = @pbt.Gen::choose_int(-1000000, 1000000)
+  @pbt.assert_check(
+    "Int -> String -> Int",
+    gen,
+    fn(n) {
+      let s = n.to_string()
+      if not(is_integer(s)) {
+        Err("is_integer(\{s}) should be true")
+      } else {
+        let parsed = parse_int(s)
+        if parsed == n { Ok(()) } else { Err("\{n} -> \{s} -> \{parsed}") }
+      }
+    },
+    config~,
+    shrink=@pbt.shrink_int,
+  )
+}
+
+///|
+/// Property: is_integer should return true for integer string representations
+test "prop_is_integer_for_ints" {
+  let config = @pbt.CheckConfig::new(500, 100, 22222, 20)
+  let gen = @pbt.Gen::choose_int(-1000000, 1000000)
+  @pbt.assert_check(
+    "is_integer(n.to_string()) == true",
+    gen,
+    fn(n) {
+      let s = n.to_string()
+      if is_integer(s) {
+        Ok(())
+      } else {
+        Err("is_integer(\{s}) should be true for \{n}")
+      }
+    },
+    config~,
+    shrink=@pbt.shrink_int,
+  )
+}

--- a/moon.mod.json
+++ b/moon.mod.json
@@ -1,9 +1,14 @@
 {
   "name": "f4ah6o/duckdb",
   "version": "0.4.0",
+  "deps": {
+    "f4ah6o/aletheia": "0.1.0"
+  },
   "readme": "README.mbt.md",
   "repository": "https://github.com/f4ah6o/duckdb.mbt",
   "license": "Apache-2.0",
-  "keywords": ["duckdb"],
+  "keywords": [
+    "duckdb"
+  ],
   "description": ""
 }

--- a/moon.pkg
+++ b/moon.pkg
@@ -1,3 +1,7 @@
+import {
+  "f4ah6o/aletheia/pbt" as @pbt,
+}
+
 options(
   "is-main": false,
   link: {
@@ -15,6 +19,7 @@ options(
     "duckdb_js.mbt": [ "js" ],
     "duckdb_js_test.mbt": [ "js" ],
     "duckdb_native.mbt": [ "native" ],
+    "duckdb_pbt_test.mbt": [ "native" ],
     "duckdb_test.mbt": [ "native" ],
     "duckdb_unsupported.mbt": [ "or", "wasm", "wasm-gc" ],
   },


### PR DESCRIPTION
## Summary

This PR introduces Property-Based Testing (PBT) to the DuckDB MoonBit bindings using the [Aletheia](https://github.com/f4ah6o/aletheia.mbt) framework. PBT complements traditional unit tests by automatically generating hundreds of random test cases to verify invariants and round-trip properties.

## Changes

- ✅ Add `f4ah6o/aletheia@0.1.0` dependency
- ✅ Implement 4 comprehensive PBT tests
- ✅ Export `is_integer` and `parse_int` functions for testing
- ✅ Configure markdown package `html_tests` for JS target only (workaround)

## PBT Test Results

| Test | Cases | Result | Notes |
|------|-------|--------|-------|
| `prop_date_roundtrip` | 1000 | ✅ Pass | `date_from_ymd`/`date_to_ymd` round-trip |
| `prop_timestamp_roundtrip` | 1000 | ❌ Fail | Bug found! (see #38) |
| `prop_parse_int_roundtrip` | 500 | ✅ Pass | Int → String → Int round-trip |
| `prop_is_integer_for_ints` | 500 | ✅ Pass | `is_integer` property |

**Total: 62/65 tests passing** (includes 3 pre-existing failures)

## Bug Discovery 🐛

PBT immediately discovered a bug in the timestamp conversion functions:
- **Input**: `(2089, 8, 19, 8, 31, 13)`
- **Expected**: `(2089, 8, 19, 8, 31, 13)`
- **Actual**: `(1970, 1, 1, 0, -31, -15)`

See issue #38 for details. This demonstrates the value of PBT in finding edge cases that traditional tests might miss.

## Testing

```bash
# Run PBT tests only
moon test --target native --filter "prop_"

# Run all tests
moon test --target native
```

## Future Work

- [ ] Fix timestamp round-trip bug (#38)
- [ ] Add PBT tests for `Value` type round-trip
- [ ] Add PBT tests for `Decimal` conversion
- [ ] Add more property patterns (idempotent, commutative, etc.)

## References

- [Aletheia PBT Framework](https://github.com/f4ah6o/aletheia.mbt)
- [Issue #38: Timestamp round-trip bug](https://github.com/f4ah6o/duckdb.mbt/issues/38)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)