### PR TITLE
test(pbt): expand property-based testing coverage

### DIFF
--- a/duckdb.mbt
+++ b/duckdb.mbt
@@ -233,7 +233,7 @@ pub fn DataChunk::cell(self : DataChunk, row : Int, col : Int) -> String? {
 
 ///|
 /// Map DuckDB type id to ColumnType.
-fn column_type_from_id(id : Int) -> ColumnType {
+pub fn column_type_from_id(id : Int) -> ColumnType {
   match id {
     0 => ColumnType::Invalid
     1 => ColumnType::Boolean
@@ -281,7 +281,7 @@ fn column_type_from_id(id : Int) -> ColumnType {
 
 ///|
 /// Infer and parse a string value into an appropriate Value type.
-fn parse_value(s : String) -> Value {
+pub fn parse_value(s : String) -> Value {
   if s == "true" {
     Value::Bool(true)
   } else if s == "false" {
@@ -407,7 +407,7 @@ pub fn is_integer(s : String) -> Bool {
 
 ///|
 /// Check if string represents a double.
-fn is_double(s : String) -> Bool {
+pub fn is_double(s : String) -> Bool {
   if s.length() == 0 {
     false
   } else {
@@ -476,7 +476,7 @@ pub fn parse_int(s : String) -> Int {
 
 ///|
 /// Parse string to Double.
-fn parse_double(s : String) -> Double {
+pub fn parse_double(s : String) -> Double {
   // For simplicity, use Int parsing and add fractional part
   let dot_index = find_dot(s)
   match dot_index {

--- a/duckdb_pbt_test.mbt
+++ b/duckdb_pbt_test.mbt
@@ -127,3 +127,218 @@ test "prop_is_integer_for_ints" {
     shrink=@pbt.shrink_int,
   )
 }
+
+// ============================================================================
+// Phase 1: ColumnType and Value Round-Trip Tests
+// ============================================================================
+
+///|
+/// Property: ColumnType ID round-trip
+/// Converting an ID to ColumnType should preserve the ID for Unknown type
+test "prop_column_type_id_roundtrip" {
+  let gen = @pbt.Gen::one_of([
+    @pbt.Gen::choose_int(0, 39),
+    @pbt.Gen::choose_int(-100, -1),
+    @pbt.Gen::choose_int(40, 1000)
+  ])
+  let config = @pbt.CheckConfig::new(500, 100, 33333, 30)
+
+  @pbt.assert_check("ColumnType ID round-trip", gen, fn(id) {
+    let ct = column_type_from_id(id)
+    match ct {
+      ColumnType::Unknown(original) => {
+        if original == id { Ok(()) }
+        else { Err("Unknown(\{original}) should contain \{id}") }
+      }
+      _ => Ok(())
+    }
+  }, config~)
+}
+
+///|
+/// Property: Value::Int round-trip
+/// Converting an integer to string and parsing should yield the original integer
+test "prop_value_int_roundtrip" {
+  let gen = @pbt.Gen::choose_int(-1000000000, 1000000000)
+  let config = @pbt.CheckConfig::new(800, 100, 44444, 30)
+
+  @pbt.assert_check("Value::Int round-trip", gen, fn(n) {
+    let str_val = n.to_string()
+    let parsed = parse_value(str_val)
+    match parsed {
+      Value::Int(m) => if m == n { Ok(()) }
+                       else { Err("\{n} -> \{str_val} -> Value::Int(\{m})") }
+      _ => Err("Expected Value::Int")
+    }
+  }, config~, shrink=@pbt.shrink_int)
+}
+
+///|
+/// Property: Value::Double round-trip
+/// Converting a double to string and parsing should yield approximately the same value
+test "prop_value_double_roundtrip" {
+  let gen = @pbt.Gen::map(
+    @pbt.Gen::choose_int(-1000000, 1000000),
+    fn(n) { n.to_double() / 1000.0 }
+  )
+  let config = @pbt.CheckConfig::new(800, 100, 55555, 30)
+
+  @pbt.assert_check("Value::Double round-trip", gen, fn(d) {
+    let str_val = d.to_string()
+    let parsed = parse_value(str_val)
+    match parsed {
+      Value::Double(d2) => {
+        let diff = if d2 > d { d2 - d } else { d - d2 }
+        if diff < 0.0001 { Ok(()) }
+        else { Err("Double mismatch: \{d} vs \{d2}, diff: \{diff}") }
+      }
+      _ => Err("Expected Value::Double")
+    }
+  }, config~)
+}
+
+///|
+/// Property: Value::Bool round-trip
+/// Converting a boolean to string and parsing should yield the original boolean
+test "prop_value_bool_roundtrip" {
+  let gen = @pbt.Gen::one_of([
+    @pbt.Gen::pure(true),
+    @pbt.Gen::pure(false)
+  ])
+  let config = @pbt.CheckConfig::new(10, 10, 66666, 5)
+
+  @pbt.assert_check("Value::Bool round-trip", gen, fn(b) {
+    let str_val = if b { "true" } else { "false" }
+    let parsed = parse_value(str_val)
+    match parsed {
+      Value::Bool(b2) => if b2 == b { Ok(()) }
+                         else { Err("Bool mismatch: \{b} vs \{b2}") }
+      _ => Err("Expected Value::Bool")
+    }
+  }, config~)
+}
+
+///|
+/// Property: Value::String round-trip
+/// Converting a string to value and parsing should yield the original string
+test "prop_value_string_roundtrip" {
+  let gen = @pbt.Gen::map(
+    @pbt.Gen::choose_int(0, 255),
+    fn(code) { "x" + code.to_string() }
+  )
+  let config = @pbt.CheckConfig::new(500, 100, 77777, 30)
+
+  @pbt.assert_check("Value::String round-trip", gen, fn(s) {
+    let parsed = parse_value(s)
+    match parsed {
+      Value::String(s2) => if s2 == s { Ok(()) }
+                           else { Err("String mismatch: \{s} vs \{s2}") }
+      _ => Err("Expected Value::String")
+    }
+  }, config~)
+}
+
+// ============================================================================
+// Phase 2: Boundary Value and Edge Case Tests
+// ============================================================================
+
+///|
+/// Property: parse_int boundary values
+/// Parsing integers should correctly handle various integer formats
+test "prop_parse_int_boundary_values" {
+  let gen = @pbt.Gen::choose_int(-1000000, 1000000)
+  let config = @pbt.CheckConfig::new(300, 100, 88888, 30)
+
+  @pbt.assert_check("parse_int boundary values", gen, fn(n) {
+    let s = n.to_string()
+    let parsed = parse_int(s)
+    if parsed == n { Ok(()) }
+    else { Err("parse_int(\{s}) = \{parsed}, expected \{n}") }
+  }, config~)
+}
+
+///|
+/// Property: is_integer edge cases
+/// is_integer should correctly identify valid and invalid integer strings
+test "prop_is_integer_edge_cases" {
+  let gen = @pbt.Gen::one_of([
+    @pbt.Gen::map(@pbt.Gen::choose_int(-10000, 10000), fn(n) { n.to_string() }),
+    @pbt.Gen::pure(""),
+    @pbt.Gen::pure("+"),
+    @pbt.Gen::pure("-"),
+    @pbt.Gen::pure("0"),
+    @pbt.Gen::pure("00"),
+    @pbt.Gen::pure("-0"),
+    @pbt.Gen::pure(" 123"),
+    @pbt.Gen::pure("+-123"),
+  ])
+  let config = @pbt.CheckConfig::new(300, 100, 121212, 30)
+
+  @pbt.assert_check("is_integer edge cases", gen, fn(s) {
+    let result = is_integer(s)
+    let is_valid = if s.length() == 0 {
+      false
+    } else {
+      let mut i = 0
+      let start = if s[0] == '-' || s[0] == '+' { 1 } else { 0 }
+      let mut has_digit = false
+      while i < s.length() {
+        let c = s[i]
+        if c >= '0' && c <= '9' {
+          has_digit = true
+        } else if i >= start {
+          has_digit = false
+          break
+        }
+        i = i + 1
+      }
+      start < s.length() && has_digit
+    }
+    if result == is_valid { Ok(()) }
+    else { Err("is_integer(\{s}) = \{result}, expected \{is_valid}") }
+  }, config~)
+}
+
+///|
+/// Property: is_double edge cases
+/// is_double should correctly identify valid and invalid double strings
+test "prop_is_double_edge_cases" {
+  let gen = @pbt.Gen::one_of([
+    @pbt.Gen::map(@pbt.Gen::choose_int(-10000, 10000), fn(n) {
+      n.to_string() + ".5"
+    }),
+    @pbt.Gen::map(@pbt.Gen::choose_int(-10000, 10000), fn(n) { n.to_string() }),
+    @pbt.Gen::pure("."),
+    @pbt.Gen::pure("1.2.3"),
+    @pbt.Gen::pure(".123"),
+    @pbt.Gen::pure("123."),
+  ])
+  let config = @pbt.CheckConfig::new(400, 100, 131313, 30)
+
+  @pbt.assert_check("is_double edge cases", gen, fn(s) {
+    let result = is_double(s)
+    let is_valid = if s.length() == 0 {
+      false
+    } else {
+      let mut dot_count = 0
+      let mut has_digit = false
+      let mut i = 0
+      let start = if s[0] == '-' || s[0] == '+' { 1 } else { 0 }
+      while i < s.length() {
+        let c = s[i]
+        if c == '.' {
+          dot_count = dot_count + 1
+        } else if c >= '0' && c <= '9' {
+          has_digit = true
+        } else if i >= start {
+          has_digit = false
+          break
+        }
+        i = i + 1
+      }
+      start < s.length() && has_digit && dot_count == 1
+    }
+    if result == is_valid { Ok(()) }
+    else { Err("is_double(\{s}) = \{result}, expected \{is_valid}") }
+  }, config~)
+}


### PR DESCRIPTION
## Summary

This PR expands the property-based testing (PBT) coverage for DuckDB MoonBit bindings by adding 8 new PBT tests using the Aletheia PBT framework.

## Changes

### New Tests (8)

**Phase 1: ColumnType and Value round-trip tests (5 tests)**
- `prop_column_type_id_roundtrip`: Verifies ColumnType ID conversion preserves IDs for unknown types
- `prop_value_int_roundtrip`: Tests Int → String → Value::Int round-trip
- `prop_value_double_roundtrip`: Tests Double → String → Value::Double round-trip
- `prop_value_bool_roundtrip`: Tests Bool → String → Value::Bool round-trip
- `prop_value_string_roundtrip`: Tests String → Value::String round-trip

**Phase 2: Boundary values and edge case tests (3 tests)**
- `prop_parse_int_boundary_values`: Tests integer parsing with various boundary values
- `prop_is_integer_edge_cases`: Validates `is_integer()` with edge cases (empty strings, signs, whitespace)
- `prop_is_double_edge_cases`: Validates `is_double()` with edge cases (multiple dots, leading/trailing dots)

### Function Visibility Changes

Made the following functions public for PBT testing:
- `is_double` (duckdb.mbt:410)
- `column_type_from_id` (duckdb.mbt:236)
- `parse_value` (duckdb.mbt:284)
- `parse_double` (duckdb.mbt:479)

## Test Results

**Total tests**: 73  
**Passed**: 69  
**Failed**: 4

### Failed Tests Breakdown
1. `native stream large range` - Pre-existing test failure
2. `typed result basic types` - Pre-existing test failure
3. `prop_timestamp_roundtrip` - Known issue (#38)
4. `prop_value_double_roundtrip` - **New bug discovered** (see #40)

### New Bug Discovered

**Issue #40**: Negative double parsing loses sign
- Input: `-925.197`
- Expected: `Value::Double(-925.197)`
- Actual: `Value::Double(924.803)`
- Location: `parse_value` function

## Coverage

**Total PBT tests**: 12 (4 existing + 8 new)

This improves the robustness of the codebase by:
- Validating round-trip conversions for all Value types
- Testing boundary conditions and edge cases
- Providing regression tests for future changes

## References

- Uses [f4ah6o/aletheia](https://github.com/f4ah6o/aletheia) PBT framework
- Related issue: #38 (timestamp round-trip bug)
- Related issue: #40 (negative double parsing bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)